### PR TITLE
feat: :wrench: Add set_sshkey to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ down:
 echo_ip:
 	networksetup -getinfo Wi-Fi
 
+set_sshkey:
+	ssh-add --apple-use-keychain ~/.ssh/github
+
 # make app_init: Access the app container
 app_init:
 	docker compose run --rm app bash


### PR DESCRIPTION
# Issue
- 

## Changes
Makefileに`set_sshkey`というコマンドを追加しました。
これは主に開発環境でDockerをビルドするために必要です。

## Commits
コミットメッセージ

